### PR TITLE
feat(SIGCORE-756): modifying uname in name template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,14 +19,8 @@ archives:
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        format: zip
+      {{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}
+
   - id: helm-plugin
     format: tar.gz
     name_template: "{{ .ProjectName }}"
@@ -35,7 +29,6 @@ archives:
     - scripts/*
     - plugin.yaml
 
-    
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There is an [open issue](https://github.com/helm/helm/issues/2247) and [PR](http
 ## Install
 
 ```bash
-wget -qO- "https://github.com/signavio/k8s-helm-dep-updater/releases/latest/download/k8s-helm-dep-updater_$(uname -s)_$(uname -m).tar.gz" | tar -C /tmp -xzf- k8s-helm-dep-updater
+wget -qO- "https://github.com/signavio/k8s-helm-dep-updater/releases/download/v1.1.1/k8s-helm-dep-updater_$(uname -s)_$(uname -m).tar.gz" | tar -C /tmp -xzf- k8s-helm-dep-updater
 sudo mv /tmp/k8s-helm-dep-updater /usr/local/bin/k8s-helm-dep-updater
 ```
 
@@ -46,8 +46,8 @@ repoServer:
       args:
         - |
           mkdir -p /custom-tools/helm-plugins/helm-dep-updater
-          wget -qO- "https://github.com/signavio/k8s-helm-dep-updater/releases/latest/download/k8s-helm-dep-updater.tar.gz" | tar -C /custom-tools/helm-plugins/helm-dep-updater -xzf-;
-          wget -qO- "https://github.com/signavio/k8s-helm-dep-updater/releases/latest/download/k8s-helm-dep-updater_$(uname -s)_$(uname -m).tar.gz" | tar -C /custom-tools/ -xzf- k8s-helm-dep-updater
+          wget -qO- "https://github.com/signavio/k8s-helm-dep-updater/releases/download/v1.1.1/k8s-helm-dep-updater.tar.gz" | tar -C /custom-tools/helm-plugins/helm-dep-updater -xzf-;
+          wget -qO- "https://github.com/signavio/k8s-helm-dep-updater/releases/download/v1.1.1/k8s-helm-dep-updater_$(uname -s)_$(uname -m).tar.gz" | tar -C /custom-tools/ -xzf- k8s-helm-dep-updater
     volumeMounts:
       - mountPath: /custom-tools
         name: custom-tools


### PR DESCRIPTION
Default setup of release packaging name has been used in [feat: add go releaser and setup ci](https://github.com/signavio/k8s-helm-dep-updater/commit/487beee048c9b03d3ee20e846a66b10538b4feda) caused all packages name from `amd64` changed to `x86_64` and also we have extra override format for `Windows` based packages which is not available. 
We utilize two specific platforms, amd64 and arm64, on Linux during our new argcd-tools build process in CircleCI. Since we don't have a Windows-based platform, using this new template maintains full compatibility with the existing operating systems and applications, without requiring any changes or impacting performance.
Moreover, using the Windows format on Linux hardware required us to hardcode the URL for this tool and utilize a script for other tools in the new argocd-tools dockerfile. Standardisation within code is also crucial, as it helps to ensure safety, security, and reliability.
By adjusting the template configuration, we could streamline the process of referring to these platforms, thereby simplifying their use as plugins or tools.

This PR will modify the template name to have package name for `amd64` and `arm64` on `linux` and will remove `zip` format to fix this issue. 

We are also modifying the urls in some repositories to ensur the latest version of packages can still be downloaded correctly using the previous version format. Kindly please make sure below PR has been accepted and merged before merging this PR  :

- [x] [#111](https://github.com/signavio/kind-local/pull/111) 
- [x] [#2914](https://github.com/signavio/suite-infrastructure/pull/2914) 
- [x] [#23210](https://github.com/signavio/suite-k8sconfig/pull/23210)
- [x] [#24625](https://github.com/signavio/suite-k8sconfig/pull/24625)