### PR TITLE
feat: add registries from argocd

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ repoServer:
 | HELM_DEPS_SKIP_REFRESH        | false               | Skips repository update for sub-dependencies, providing a significant performance boost.                 |
 | HELM_DEPS_SKIP_START_LOGIN    | false               | Skips login to all available registries at the start if combined with HELM_DEPS_SKIP_REFRESH=true.       |
 | HELM_DEPS_FETCH_ARGOCD_REPO_SECRETS | false | Adds registries that are registered in the argocd repository secrets.                                     |
+| HELM_DEPS_RANDOM_CACHE_DIR | false | Uses a random cache directory for the helm plugin. Useful for parallel executions when using in ArgoCD. This give additional speed boost of ~30% |
 
 ### Local
 
@@ -123,6 +124,9 @@ helm template . -f deps://dummy -f env/qa/values.yaml  200.83s user 19.00s syste
 export HELM_DEPS_SKIP_REFRESH=true
 export HELM_DEPS_SKIP_REPO_OVERWRITE=true
 export HELM_DEPS_SKIP_START_LOGIN=true
-helm template . -f deps://dummy -f env/qa/values.yaml  129.04s user 8.81s system 286% cpu 48.064 total # V2 max performance
+helm template . -f deps://dummy -f env/qa/values.yaml  129.04s user 8.81s system 286% cpu 48.064 total # V2 Performance
+
+export HELM_DEPS_RANDOM_CACHE_DIR=true
+helm template -f env/qa/values.yaml -f deps://dummy . > app.yaml  41.07s user 6.11s system 184% cpu 25.541 total # V2 Performance with Random Cache Dir
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ repoServer:
 | HELM_DEPS_SKIP_REPO_OVERWRITE | false               | Skips adding the repository if it already exists, useful during testing.                                 |
 | HELM_DEPS_SKIP_REFRESH        | false               | Skips repository update for sub-dependencies, providing a significant performance boost.                 |
 | HELM_DEPS_SKIP_START_LOGIN    | false               | Skips login to all available registries at the start if combined with HELM_DEPS_SKIP_REFRESH=true.       |
+| HELM_DEPS_FETCH_ARGOCD_REPO_SECRETS | false | Adds registries that are registered in the argocd repository secrets.                                     |
 
 ### Local
 

--- a/helm.go
+++ b/helm.go
@@ -32,8 +32,9 @@ type HelmUpdater struct {
 }
 
 type HelmUpdateConfig struct {
-	SkipRepoOverwrite bool
+	SkipRepoOverwrite bool // ENV: HELM_DEPS_SKIP_REPO_OVERWRITE
 	SkipDepdencyRefresh bool // ENV: HELM_DEPS_SKIP_REFRESH
+	FetchArgocdRepoSecrets bool // ENV: HELM_DEPS_FETCH_ARGOCD_REPO_SECRETS
 }
 
 func (c *ChartInfo) AddDependencyUrl(depdencyUrl string) error {

--- a/kube.go
+++ b/kube.go
@@ -82,7 +82,7 @@ func (d *DefaultStrategy) Logout() error {
 
 // NewRegistryHelper creates a new RegistryHelper
 // secretNames is a comma separated list of registry secrets
-func NewRegistryHelper(secretNames string, namespace string, config *HelmUpdateConfig) *RegistryHelper {
+func NewRegistryHelper(secretNames string, namespace string, config *HelmUpdateConfig) (*RegistryHelper, error) {
 	registryMap := make(map[string]*RegistryInfo)
 	for _, registry := range strings.Split(secretNames, ",") {
 		if registry != "" {
@@ -95,9 +95,12 @@ func NewRegistryHelper(secretNames string, namespace string, config *HelmUpdateC
 		config:     config,
 	}
 	if config.UseRandomHelmCacheDir {
-		r.SetRandomHelmCacheDir()
+		err := r.SetRandomHelmCacheDir()
+		if err != nil {
+			return r, err
+		}
 	}
-	return r
+	return r, nil
 }
 
 func (r *RegistryHelper) SetRandomHelmCacheDir() error {
@@ -153,7 +156,7 @@ func (r *RegistryHelper) LoginIfExists(registry *RegistryInfo) error {
 		return action.Login()
 	}
 	if !registry.EnableOCI {
-		log.Printf("Registry %s ≈", registry.SecretName)
+		log.Printf("Registry %s not found in secrets, adding it as a repo", registry.SecretName)
 		action := GetRegistryAction(registry)
 		return action.Login()
 	}

--- a/kube.go
+++ b/kube.go
@@ -126,6 +126,17 @@ func (r *RegistryHelper) SetRandomHelmCacheDir() error {
 	return nil
 }
 
+func (r *RegistryHelper) RemoveTempHelmCacheDir() {
+	cacheDir := os.Getenv("HELM_REPOSITORY_CACHE")
+	configDir := os.Getenv("HELM_REPOSITORY_CONFIG")
+	if cacheDir != "" && strings.HasPrefix(cacheDir, "/tmp/helm_cache_") {
+		os.RemoveAll(cacheDir)
+	}
+	if configDir != "" && strings.HasPrefix(configDir, "/tmp/helm_config_") {
+		os.RemoveAll(filepath.Dir(configDir))
+	}
+}
+
 // GetRegistry returns the credential protected registry by hostname
 func (r *RegistryHelper) GetRegistryByHostname(registry string) *RegistryInfo {
 	for _, registryInfo := range r.Registries {

--- a/main.go
+++ b/main.go
@@ -15,14 +15,13 @@ import (
 
 func main() {
 
-	
 	chartPath := flag.String("chartPath", ".", "path to the chart")
 	secretNamespace := flag.String("secretNamespace", "argocd", "namespace where the secret is located")
 	secretNames := flag.String("registries", os.Getenv("HELM_DEPS_SECRET_NAMES"), "comma separated list of registries to update")
 	// DEPRECATED: this flag not required anymore, since the repo secret contains OCI flag already
 	// if repo credentials have this flag we need to use registry login insteaad of repo add
 	addRegistries := flag.String("add-registries", os.Getenv("HELM_DEPS_SECRET_NAMES_REPO_ADD"), "DEPRECATED only registries flag is required: comma separated list of registries using 'helm repo add'")
-	
+
 	// this will skip adding the repo if it already exists. useful during testing, if the depdenccy are already added
 	skipRepoOverwrite := parseBoolEnv("HELM_DEPS_SKIP_REPO_OVERWRITE", false)
 	// skips repo update in sub dependencies and give massive performance improvement
@@ -32,12 +31,15 @@ func main() {
 	skipDepRefreshFlag := flag.Bool("skip-dep-refresh", skipDepRefresh, "Set environment variable HELM_DEPS_SKIP_REFRESH to use this flag (default false). run repo refresh in every sub dependency. this will add the helm argument --skip-refresh to helm dependency update")
 	skipRepoOverwriteFlag := flag.Bool("skip-repo-overwrite", skipRepoOverwrite, "Env: HELM_DEPS_SKIP_REPO_OVERWRITE (default true). This will not add a repo if it already exists")
 	skipLoginAtStartFlag := flag.Bool("skip-login-at-start", skipLoginAtStart, "Env: HELM_DEPS_SKIP_START_LOGIN (default false). This will skip login to all available registry at the start in combination with HELM_DEPS_SKIP_REFRESH=true")
+	fetchArgocdRepoSecrets := parseBoolEnv("HELM_DEPS_FETCH_ARGOCD_REPO_SECRETS", false)
+	fetchArgocdRepoSecretsFlag := flag.Bool("fetch-argocd-repo-secrets", fetchArgocdRepoSecrets, "Env: HELM_DEPS_FETCH_ARGOCD_REPO_SECRETS (default false). Fetch the argocd repository secrets as registries")
 
 	flag.Parse()
 
 	config := &HelmUpdateConfig{
-		SkipRepoOverwrite:   *skipRepoOverwriteFlag,
-		SkipDepdencyRefresh: *skipDepRefreshFlag,
+		FetchArgocdRepoSecrets: *fetchArgocdRepoSecretsFlag,
+		SkipRepoOverwrite:      *skipRepoOverwriteFlag,
+		SkipDepdencyRefresh:    *skipDepRefreshFlag,
 	}
 	// just for backward compatibility
 	comnbinedSecretNames := strings.Join([]string{*secretNames, *addRegistries}, ",")

--- a/main.go
+++ b/main.go
@@ -33,6 +33,8 @@ func main() {
 	skipLoginAtStartFlag := flag.Bool("skip-login-at-start", skipLoginAtStart, "Env: HELM_DEPS_SKIP_START_LOGIN (default false). This will skip login to all available registry at the start in combination with HELM_DEPS_SKIP_REFRESH=true")
 	fetchArgocdRepoSecrets := parseBoolEnv("HELM_DEPS_FETCH_ARGOCD_REPO_SECRETS", false)
 	fetchArgocdRepoSecretsFlag := flag.Bool("fetch-argocd-repo-secrets", fetchArgocdRepoSecrets, "Env: HELM_DEPS_FETCH_ARGOCD_REPO_SECRETS (default false). Fetch the argocd repository secrets as registries")
+	useRandomHelmCacheDir := parseBoolEnv("HELM_DEPS_RANDOM_CACHE_DIR", false)
+	useRandomHelmCacheDirFlag := flag.Bool("use-random-helm-cache-dir", useRandomHelmCacheDir, "Env: HELM_DEPS_RANDOM_CACHE_DIR (default false). Use a random cache directory for helm")
 
 	flag.Parse()
 
@@ -40,6 +42,7 @@ func main() {
 		FetchArgocdRepoSecrets: *fetchArgocdRepoSecretsFlag,
 		SkipRepoOverwrite:      *skipRepoOverwriteFlag,
 		SkipDepdencyRefresh:    *skipDepRefreshFlag,
+		UseRandomHelmCacheDir:  *useRandomHelmCacheDirFlag,
 	}
 	// just for backward compatibility
 	comnbinedSecretNames := strings.Join([]string{*secretNames, *addRegistries}, ",")

--- a/main.go
+++ b/main.go
@@ -46,9 +46,11 @@ func main() {
 	}
 	// just for backward compatibility
 	comnbinedSecretNames := strings.Join([]string{*secretNames, *addRegistries}, ",")
-	registryHelper := NewRegistryHelper(comnbinedSecretNames, *secretNamespace, config)
-
-	err := registryHelper.UpdateRegistryInfo()
+	registryHelper, err := NewRegistryHelper(comnbinedSecretNames, *secretNamespace, config)
+	if err != nil {
+		log.Fatal("Unable to create random helm chart cache dir: ", err)
+	}
+	err = registryHelper.UpdateRegistryInfo()
 	if err != nil {
 		log.Fatal("Unable to update registry info: ", err)
 	}

--- a/main.go
+++ b/main.go
@@ -54,6 +54,9 @@ func main() {
 	if err != nil {
 		log.Fatal("Unable to update registry info: ", err)
 	}
+	if registryHelper.config.UseRandomHelmCacheDir {
+		defer registryHelper.RemoveTempHelmCacheDir() // nolint: errcheck
+	}
 
 	if !*skipLoginAtStartFlag {
 		err := registryHelper.LoginAll()


### PR DESCRIPTION
* add option `HELM_DEPS_FETCH_ARGOCD_REPO_SECRETS` to fetch any existing repo credentials with the need to set secret names
* add option `HELM_DEPS_RANDOM_CACHE_DIR` to avoid file locks on repository cache file if multiple processes running at the same time
* fix `helm repo ls` bug when no repo existed