### PR TITLE
fix: make oci login work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Chart.lock
 !./charts
 k8s-helm-dep-updater
 dist/
+.DS_Store

--- a/charts/benchmark-subchart-level-2a/Chart.yaml
+++ b/charts/benchmark-subchart-level-2a/Chart.yaml
@@ -37,3 +37,7 @@ dependencies:
     alias: mysql-bitnami-benchmark-subchart-level-2a
     version: 12.0.0
     repository: https://charts.bitnami.com/bitnami
+  - name: redis
+    alias: redis-bitnami-benchmark-subchart-level-2a
+    version: 20.6.1
+    repository: oci://registry-1.docker.io/bitnamicharts

--- a/helm_test.go
+++ b/helm_test.go
@@ -28,13 +28,13 @@ func TestUpdateDependencies(t *testing.T) {
 			name:                "With Refresh",
 			chartPath:           "charts/benchmark-subchart-level-1",
 			helmDepsSkipRefresh: false,
-			expectedNumObjects:  42,
+			expectedNumObjects:  56,
 		},
 		{
 			name:                "Without Refresh",
 			chartPath:           "charts/benchmark-subchart-level-1",
 			helmDepsSkipRefresh: true,
-			expectedNumObjects:  42,
+			expectedNumObjects:  56,
 		},
 	}
 


### PR DESCRIPTION
this lookup for oci credentials in secret was wrong. it tried to lookup will repository name like `oci://registry-1.docker.io/bitnamicharts` but it should look for `registry-1.docker.io`

also we only need secrets with type helm